### PR TITLE
Replace rustls with native-tls to remove ring dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ exclude = [
 ]
 
 [dependencies]
-duroxide = { version = "0.1.27", path = "../../duroxide", features = ["provider-test"] }
+duroxide = { version = "0.1.27", features = ["provider-test"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono"], default-features = false }
+sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres", "chrono"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dotenvy = "0.15"

--- a/pg-stress/Cargo.toml
+++ b/pg-stress/Cargo.toml
@@ -9,7 +9,7 @@ name = "pg-stress"
 path = "src/bin/pg-stress.rs"
 
 [dependencies]
-duroxide = { version = "0.1.27", path = "../../../duroxide", features = ["provider-test"] }
+duroxide = { version = "0.1.27", features = ["provider-test"] }
 duroxide-pg = { path = ".." }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"


### PR DESCRIPTION
The `ring` crate is not FIPS compliant. This PR switches the sqlx TLS backend from `runtime-tokio-rustls` to `runtime-tokio-native-tls` to eliminate the transitive dependency on `ring` from this crate.

This is the duroxide-pg side of the change. A corresponding change in the duroxide crate will also be needed to fully remove `ring` from the resolved dependency tree.