### PR TITLE
Register only the federated credential format the repo actually uses

### DIFF
--- a/docs/entra-ci.md
+++ b/docs/entra-ci.md
@@ -15,7 +15,7 @@ One-time provisioning (see `scripts/provision_entra_ci_pg.sh`) creates:
 | PG Flex Server | `pg-duroxide-entra-ci` | Burstable B1ms, **Entra-only auth** (password auth disabled), PG 16 |
 | Firewall rule | `allow-public` | `0.0.0.0`–`255.255.255.255`. Safe because Entra is the auth gate and the server has no production data. |
 | AAD application | `duroxide-pg-entra-ci` | Workload-identity-federated; **no client secret** |
-| Federated creds | `github-pr`, `github-main` | Subjects: `repo:microsoft/duroxide-pg:pull_request`, `repo:microsoft/duroxide-pg:ref:refs/heads/main` |
+| Federated creds | `github-pr-id`, `github-main-id` | Subjects: `repository_owner_id:6154722:repository_id:1157352866:pull_request`, `...:ref:refs/heads/main`. The `microsoft` org customizes the OIDC subject claim to the ID-based form — see [OIDC subject format](#oidc-subject-format). |
 | Entra admin | the SP above | Service principal is the test user |
 
 Approximate cost: ~$15-20/month for the Burstable B1ms server.
@@ -30,8 +30,9 @@ PR triggers workflow
          ▼                                  
 azure/login@v2                              
    issues OIDC token w/ subject ───────►   AAD app verifies federated
-   "repo:microsoft/duroxide-pg:             credential matches subject;
-    pull_request"                           returns AAD access token
+   "repository_owner_id:6154722:            credential matches subject;
+    repository_id:1157352866:               returns AAD access token
+    pull_request"                          
          │                                  
          ▼                                  
 sets env: AZURE_FEDERATED_TOKEN_FILE,       
@@ -110,14 +111,44 @@ runs on PR + nightly + manual dispatch:
       live test, which connects to the PG server using a fresh Entra token
       and exercises schema migrations + a basic query.
 
+## OIDC subject format
+
+GitHub issues **exactly one** subject per OIDC token. Its format depends on the
+repository's [subject claim customization][gh-sub]:
+
+| `use_default` | Subject format |
+|---|---|
+| `true` (GitHub default) | `repo:OWNER/REPO:<context>` |
+| `false` (this repo) | the customized claim keys, e.g. `repository_owner_id:<id>:repository_id:<id>:<context>` |
+
+The `microsoft` org customizes it to the ID-based form, which resists
+repo-rename attacks. Check the current setting with:
+
+```bash
+gh api repos/microsoft/duroxide-pg/actions/oidc/customization/sub
+# {"use_default":false,"include_claim_keys":["repository_owner_id","repository_id","context"], ...}
+```
+
+**Only register credentials in the format this repo actually emits.** A
+credential in the other format can never match, so it is permanent dead weight
+on the app — and tenant security sweeps delete such credentials, which looks
+exactly like CI breaking for no reason. `scripts/provision_entra_ci_pg.sh`
+detects the format and registers only the matching pair; it warns about any
+leftovers in the other format.
+
+> Because both credentials depend on this customization, resetting it to
+> `use_default: true` (or transferring the repo) breaks `main` and PR auth
+> simultaneously.
+
 ## Updating the federated credentials
 
 To allow another branch / environment to use the same AAD app, add another
-federated credential. Examples of valid GitHub OIDC subjects:
+federated credential. Build the subject from this repo's ID-based prefix
+`repository_owner_id:6154722:repository_id:1157352866:` plus the context:
 
-- `repo:OWNER/REPO:pull_request`
-- `repo:OWNER/REPO:ref:refs/heads/BRANCH`
-- `repo:OWNER/REPO:environment:ENVNAME`
+- `...:pull_request`
+- `...:ref:refs/heads/BRANCH`
+- `...:environment:ENVNAME`
 
 Add via:
 
@@ -125,12 +156,16 @@ Add via:
 az ad app federated-credential create \
   --id "$APP_ID" \
   --parameters '{
-    "name": "github-release",
+    "name": "github-release-id",
     "issuer": "https://token.actions.githubusercontent.com",
-    "subject": "repo:microsoft/duroxide-pg:ref:refs/tags/v*",
+    "subject": "repository_owner_id:6154722:repository_id:1157352866:ref:refs/tags/v1.0.0",
     "audiences": ["api://AzureADTokenExchange"]
   }'
 ```
+
+> Subjects are matched **exactly** — wildcards are not supported. Re-running
+> `scripts/provision_entra_ci_pg.sh` is the safer way to restore the standard
+> pair, since it derives the subjects from the live GitHub API.
 
 ## Teardown
 
@@ -145,6 +180,18 @@ shot) and the AAD application (federated creds + SP go with it).
 
 - **Workflow logs `Skipping live Entra test — missing repo vars`** — set
   the six repository variables (see Setup).
+- **`AADSTS700213` from `azure/login@v2`** — "No matching federated identity
+  record found for presented assertion subject". The app has no credential for
+  the subject GitHub sent. The error message quotes the exact subject received;
+  compare it against the app's credentials and re-run
+  `scripts/provision_entra_ci_pg.sh` to restore the standard pair:
+  ```bash
+  az ad app federated-credential list --id "$APP_ID" \
+    --query '[].{name:name,subject:subject}' -o table
+  ```
+  If `main` works but PRs fail (or vice versa), only one of the two credentials
+  is missing — this is what a deleted credential looks like, so check the
+  [Entra audit log](#auditing-credential-changes) before assuming misconfiguration.
 - **`AADSTS70021` from `azure/login@v2`** — the federated credential's
   `subject` doesn't match the workflow's actual OIDC subject. The
   `pull_request` subject only matches PR runs from the same repo, not
@@ -175,4 +222,21 @@ shot) and the AAD application (federated creds + SP go with it).
   chain. Running the live test through federated identity validates the
   primary credential path, not a developer-only fallback.
 
+## Auditing credential changes
+
+Federated credentials can be removed out-of-band (tenant security sweeps have
+done exactly this), and the only symptom is a failing `azure/login@v2` step.
+The Entra audit log records every change, including the before/after subject:
+
+```bash
+APP_OBJECT_ID=$(az ad app show --id "$APP_ID" --query id -o tsv)
+az rest --method GET --url \
+  "https://graph.microsoft.com/v1.0/auditLogs/directoryAudits?\$filter=targetResources/any(t:t/id eq '$APP_OBJECT_ID')&\$top=50"
+```
+
+Look for `Update application` entries whose `modifiedProperties` include
+`FederatedIdentityCredentials`; `oldValue` and `newValue` show exactly which
+credentials existed before and after.
+
+[gh-sub]: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-subject-claims-for-an-organization-or-repository
 [gh-oidc]: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

--- a/scripts/provision_entra_ci_pg.sh
+++ b/scripts/provision_entra_ci_pg.sh
@@ -15,9 +15,11 @@
 #                                                       the server)
 #   * AAD application    duroxide-pg-entra-ci          (federated workload identity)
 #   * Service principal  for the application
-#   * Federated creds    on the AAD app:
-#                          - repo:OWNER/REPO:pull_request
-#                          - repo:OWNER/REPO:ref:refs/heads/main
+#   * Federated creds    on the AAD app, in whichever subject format this
+#                        repo's OIDC token actually uses:
+#                          - ID-based    when the repo customizes the OIDC
+#                            subject claim (the microsoft org does), else
+#                          - repo-slug   when it uses GitHub's default
 #   * Entra admin        the application's service principal
 #
 # The script also prints the exact `gh variable set` commands (or the values
@@ -25,7 +27,10 @@
 #
 # Required:
 #   * az CLI logged in (`az login`)
-#   * gh CLI (optional; only used when --auto-set-vars is passed)
+#   * jq
+#   * gh CLI authenticated with read access to $GH_REPO. This is required (not
+#     optional): the federated credential subject format depends on the repo's
+#     OIDC subject-claim customization, which is read via the GitHub API.
 #
 # Optional env vars:
 #   GH_REPO              Repo slug, default "microsoft/duroxide-pg"
@@ -55,6 +60,7 @@ warn() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
 require() { command -v "$1" >/dev/null 2>&1 || { err "Missing on PATH: $1"; exit 1; }; }
 require az
 require jq
+require gh
 
 AUTO_SET_VARS=0
 for arg in "$@"; do
@@ -141,28 +147,65 @@ add_federated() {
     ok "Federated credential '$name' created."
 }
 
-add_federated "github-pr"   "repo:${GH_REPO}:pull_request"
-add_federated "github-main" "repo:${GH_REPO}:ref:refs/heads/main"
+# GitHub emits exactly ONE subject per OIDC token, and its format depends on the
+# repo's "subject claim customization":
+#
+#   use_default: true   ->  repo:OWNER/REPO:<context>
+#   use_default: false  ->  the customized claim keys, e.g.
+#                           repository_owner_id:<id>:repository_id:<id>:<context>
+#
+# The microsoft org customizes it to the ID-based form (resists repo-rename
+# attacks). Registering the other format "just in case" is NOT harmless: such a
+# credential can never match, so it is permanent dead weight on the app and gets
+# flagged and removed by tenant security sweeps. Register only the matching pair.
 
-# Some GitHub orgs (including microsoft) customize the OIDC subject claim to
-# include repository_owner_id and repository_id (resists rename attacks).
-# Detect that customization via the GitHub API and register matching FICs.
-if command -v gh >/dev/null 2>&1; then
-    sub_template=$(gh api "repos/${GH_REPO}/actions/oidc/customization/sub" 2>/dev/null || true)
-    if [ -n "$sub_template" ] && echo "$sub_template" | grep -q '"repository_id"'; then
-        owner_id=$(gh api "repos/${GH_REPO}" --jq '.owner.id' 2>/dev/null || true)
-        repo_id=$(gh api "repos/${GH_REPO}" --jq '.id' 2>/dev/null || true)
-        if [ -n "$owner_id" ] && [ -n "$repo_id" ]; then
-            id_prefix="repository_owner_id:${owner_id}:repository_id:${repo_id}"
-            info "Org uses ID-based OIDC subject; registering ID-based FICs."
-            add_federated "github-pr-id"   "${id_prefix}:pull_request"
-            add_federated "github-main-id" "${id_prefix}:ref:refs/heads/main"
-        else
-            warn "Could not look up owner/repo IDs via gh; skipping ID-based FICs."
-        fi
+if ! sub_template=$(gh api "repos/${GH_REPO}/actions/oidc/customization/sub" 2>/dev/null); then
+    err "Could not read the OIDC subject-claim template for ${GH_REPO}."
+    err "The federated credential subject format depends on it, so continuing"
+    err "would likely create credentials that never match. Check that gh is"
+    err "authenticated with read access to the repo:"
+    err "  gh auth status && gh api repos/${GH_REPO}"
+    exit 1
+fi
+
+# Note: jq's `//` operator treats `false` as absent, so `(.use_default // true)`
+# would wrongly yield true here. Compare against true directly instead.
+if echo "$sub_template" | jq -e '(.use_default != true)
+        and ((.include_claim_keys // []) | index("repository_id")) != null' >/dev/null; then
+    owner_id=$(gh api "repos/${GH_REPO}" --jq '.owner.id' 2>/dev/null || true)
+    repo_id=$(gh api "repos/${GH_REPO}" --jq '.id' 2>/dev/null || true)
+    if [ -z "$owner_id" ] || [ -z "$repo_id" ]; then
+        err "${GH_REPO} uses an ID-based OIDC subject, but its owner/repo IDs"
+        err "could not be read via gh. Refusing to continue: the app would be"
+        err "left with no usable federated credential."
+        exit 1
     fi
+    id_prefix="repository_owner_id:${owner_id}:repository_id:${repo_id}"
+    info "Repo uses an ID-based OIDC subject; registering ID-based FICs."
+    FIC_PR="github-pr-id"
+    FIC_MAIN="github-main-id"
+    add_federated "$FIC_PR"   "${id_prefix}:pull_request"
+    add_federated "$FIC_MAIN" "${id_prefix}:ref:refs/heads/main"
 else
-    warn "gh CLI not found; skipping ID-based OIDC subject FICs."
+    info "Repo uses the default OIDC subject; registering repo-slug FICs."
+    FIC_PR="github-pr"
+    FIC_MAIN="github-main"
+    add_federated "$FIC_PR"   "repo:${GH_REPO}:pull_request"
+    add_federated "$FIC_MAIN" "repo:${GH_REPO}:ref:refs/heads/main"
+fi
+
+# Surface credentials left over from a previous subject format. They can never
+# match a token from this repo, and tenant security sweeps delete them -- which
+# is indistinguishable from CI breaking for no reason unless you know to look.
+stale=$(az ad app federated-credential list --id "$APP_ID" \
+    --query "[?name!='${FIC_PR}' && name!='${FIC_MAIN}'].name" -o tsv 2>/dev/null || true)
+if [ -n "$stale" ]; then
+    warn "Federated credentials that do not match ${GH_REPO}'s OIDC subject format:"
+    printf '%s\n' "$stale" | while IFS= read -r n; do
+        [ -n "$n" ] && warn "    - $n"
+    done
+    warn "These can never match a token from this repo. Remove them with:"
+    warn "    az ad app federated-credential delete --id $APP_ID --federated-credential-id NAME"
 fi
 
 # ---------- Postgres Flexible Server ----------


### PR DESCRIPTION
## Problem

The Entra Live Test fails on PRs during `azure/login@v2` with:

```
AADSTS700213: No matching federated identity record found for presented
assertion subject 'repository_owner_id:6154722:repository_id:1157352866:pull_request'
```

`main` and scheduled runs pass; only PRs fail.

## Root cause

GitHub emits **exactly one** subject per OIDC token, and its format depends on the repo's [subject claim customization](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-subject-claims-for-an-organization-or-repository):

```console
$ gh api repos/microsoft/duroxide-pg/actions/oidc/customization/sub
{"use_default":false,"include_claim_keys":["repository_owner_id","repository_id","context"], ...}
```

With `use_default: false`, the `repo:OWNER/REPO:...` form is **never emitted**. But this script registered both formats unconditionally:

```bash
add_federated "github-pr"   "repo:${GH_REPO}:pull_request"        # can never match
add_federated "github-main" "repo:${GH_REPO}:ref:refs/heads/main" # can never match
# ...then, only if gh happened to be present, the ID-based pair
```

So every app it provisioned carried two permanently-dead credentials. A tenant security sweep (`SFIInitiative_July8`) later removed them and took `github-pr-id` with them:

| Date | Event |
|---|---|
| 2026-07-08 | Sweep appended `*SFIInitiative_July8` to the subjects of `github-pr`, `github-main`, and `github-pr-id`, silently breaking them |
| 2026-07-16 | Sweep deleted all three |

`github-main-id` was untouched, which is why `main` kept working and made this look like a PR-specific misconfiguration rather than a deletion.

The credential has been restored out-of-band; this PR stops the script from recreating the problem.

## Changes

- **Register only the matching pair.** Detect the customization and register either the ID-based or the repo-slug credentials, never both.
- **Fail loudly instead of silently.** `gh` is now a hard requirement. Previously, if `gh` was missing or the repo lookup failed, the script *warned and skipped* the ID-based credentials, happily provisioning an app that could never authenticate.
- **Surface leftovers.** Warn about credentials in the other format so they are visible before a sweep removes them.
- **Docs** for the subject formats, the `AADSTS700213` failure mode, and how to audit credential changes via the Entra audit log.

Also corrected a wrong example in the docs: FIC subjects are matched exactly, so the previous `refs/tags/v*` wildcard example could never have worked.

## A jq gotcha worth flagging

The first version of the detection used `(.use_default // true) == false`. jq's `//` treats **`false`** as absent, so that yields `true` for `use_default: false`, inverting the check. Verified against the real templates and edge cases:

| Input | Result |
|---|---|
| real `duroxide-pg` / `duroxide-pg-opt` (`use_default:false`, has `repository_id`) | ID-based |
| `{"use_default":true}` | repo-slug |
| `{"use_default":false,"include_claim_keys":["repo","context"]}` | repo-slug |
| `{}` | repo-slug |

## Testing

- `bash -n` clean.
- Branch-selection logic unit-tested against the five cases above.
- Not re-run end-to-end: the script mutates the live shared CI app and PG server. It is idempotent, so a maintainer can re-run it to confirm it reports both credentials already exist.

## Note for the sister repo

`microsoft/duroxide-pg-opt` has the identical script and was hit by the same sweep on the same days. Its `github-pr-id` has also been restored, and a matching PR follows, including a fix for its script defaulting to *this* repo's `GH_REPO`/`APP_NAME`.

## Follow-up (not in this PR)

This was a deliberate, cadenced security sweep, not drift. Re-adding the credential does not exempt the app, so it is worth confirming with the sweep owner whether a bare `...:pull_request` subject is acceptable or should be narrowed to an environment-scoped subject.
