### PR TITLE
perf(worker_queue): partial index + two-phase fetch_work_item dequeue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **Stop `fetch_work_item` from scanning the future-visible backlog (migration
+  `0022`).** Inside the PL/pgSQL function the dequeue `SELECT` is cached as a
+  *generic* plan, which cannot estimate `visible_at <= $param` and so walks
+  `worker_queue_pkey` in `id` order, filtering every row whose `visible_at` is
+  still in the future — O(future-visible rows) per dequeue (~0.44 µs/row; ~44 ms
+  at 100k, crossing 10 ms near 25k). `fetch_work_item` now adds a redundant
+  `AND visible_at <= statement_timestamp()` bound, which the generic plan *can*
+  estimate, so it uses `idx_worker_visible` instead; measured flat at ~12 µs out
+  to 100k future-visible rows, with no dequeue-throughput regression. Behaviour is
+  otherwise unchanged: a row is returned only if it also passes the existing
+  application-clock bound. Caveat: this re-introduces a database-clock dependency
+  for visibility gating (cf. migration `0006`); if a worker's clock runs ahead of
+  the database's, a due timer fires late by up to the skew — bounded, self-healing,
+  never lost. Reproduce via `scripts/bench-fetch-work-item.sh`.
 - **Make mostly-NULL secondary indexes partial (migration `0023`).** Three
   secondary indexes cover columns that are NULL for the majority of rows, yet a
   plain B-tree still stored an entry for every row: `worker_queue.session_id`
@@ -22,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   i.e. non-session/untagged, population), so a session- or tag-heavy workload sees
   little benefit — but no regression, as value lookups still use the indexes.
   Reproduce via `scripts/bench-secondary-indexes.sh`.
-  (`0022` is reserved by the concurrent worker_queue dequeue change; this migration
-  is independent of it.)
 
 ### Security
 

--- a/migrations/0022_fix_fetch_work_item_generic_plan.sql
+++ b/migrations/0022_fix_fetch_work_item_generic_plan.sql
@@ -1,0 +1,194 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the MIT License.
+
+-- Migration 0022: Fix fetch_work_item's generic-plan scan of the future-visible backlog
+--
+-- Problem
+-- -------
+-- fetch_work_item selects the oldest eligible row with
+--   WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+--     AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms) ...
+--   ORDER BY q.id LIMIT 1 FOR UPDATE OF q SKIP LOCKED
+-- Inside a PL/pgSQL function the parameterised predicate is planned once and
+-- cached as a *generic* plan (after ~5 calls). The generic planner cannot
+-- estimate the selectivity of `visible_at <= $param`, so with `ORDER BY id
+-- LIMIT 1` it assumes it will hit a match early and walks worker_queue_pkey in
+-- id order, filtering as it goes. When rows whose `visible_at` is still in the
+-- future sort before the first visible row, it filters the entire
+-- future-visible backlog by hand -- O(future-visible rows) per dequeue.
+--
+-- Measured (PostgreSQL 16, one visible row + N future-visible rows):
+--   N=10k   -> ~4.4 ms      N=100k -> ~44 ms      N=1,000,000 -> ~440 ms
+-- Growth is exactly linear (~0.000439 ms/row, r^2 = 1.00) and crosses 10 ms at
+-- ~25,000 future-visible rows. The identical query with literal values runs in
+-- ~0.006 ms using the existing idx_worker_visible(visible_at, lock_token); the
+-- cost is the generic plan, not a missing index. Reproduces on main
+-- independently of any queue/index change. See
+-- docs/analysis/fetch-work-item-generic-plan.md.
+--
+-- Fix
+-- ---
+-- Add a second, redundant upper bound to the same predicate:
+--   AND q.visible_at <= statement_timestamp()
+-- `statement_timestamp()` is a stable expression the planner *can* estimate
+-- against the visible_at histogram, so the cached generic plan uses
+-- idx_worker_visible instead of the primary-key walk. Measured flat at
+-- ~12 us out to 100,000 future-visible rows, with no dequeue-throughput
+-- regression (unlike forcing a custom plan, which cost ~16-20%). The
+-- authoritative `visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)` bound is kept,
+-- so nothing else about the eligibility test changes.
+--
+-- Correctness caveat (reviewers: please confirm before relying on this)
+-- --------------------------------------------------------------------
+-- A row is returned only if it passes BOTH bounds, so there is no possibility
+-- of returning a not-yet-visible row, no duplication, and no reordering. The
+-- only observable effect is a liveness one: because the added bound also gates
+-- visibility on the DATABASE clock (statement_timestamp()), a due item is
+-- withheld until the server clock reaches its visible_at. If a worker's clock
+-- runs AHEAD of the database's, a delayed/timer item fires late by up to the
+-- clock skew (self-healing, bounded, never lost).
+--
+-- Note the tension with migration 0006 (use_rust_timestamps), which
+-- deliberately moved all time logic onto the application-supplied p_now_ms to
+-- avoid depending on the database clock. This bound re-introduces a
+-- database-clock dependency for visibility gating only. In deployments where
+-- the application and database hosts are NTP-disciplined the skew is small and
+-- the late-firing window is negligible; if the application clock cannot be
+-- assumed to be at or behind the database clock, this fix must be guarded or a
+-- clock-agnostic alternative (e.g. force_custom_plan, at a throughput cost)
+-- chosen instead. See docs/analysis/custom-plan-cost.md.
+--
+-- Scope: worker_queue's fetch_work_item only. fetch_orchestration_item shares
+-- the same PL/pgSQL generic-plan shape and is left as a follow-up.
+
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    EXECUTE format('DROP FUNCTION IF EXISTS %1$I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT)', v_schema_name);
+    EXECUTE format('DROP FUNCTION IF EXISTS %1$I.fetch_work_item(BIGINT, BIGINT, TEXT, BIGINT, TEXT[], TEXT)', v_schema_name);
+
+    EXECUTE format($body$
+        CREATE OR REPLACE FUNCTION %1$I.fetch_work_item(
+            p_now_ms BIGINT,
+            p_lock_timeout_ms BIGINT,
+            p_owner_id TEXT DEFAULT NULL,
+            p_session_lock_timeout_ms BIGINT DEFAULT NULL,
+            p_tag_filter TEXT[] DEFAULT NULL,
+            p_tag_mode TEXT DEFAULT 'default_only'
+        )
+        RETURNS TABLE(
+            out_work_item TEXT,
+            out_lock_token TEXT,
+            out_attempt_count INTEGER
+        ) AS $fetch_worker$
+        DECLARE
+            v_id BIGINT;
+            v_session_id TEXT;
+            v_session_locked_until BIGINT;
+        BEGIN
+            -- none mode: return immediately with no results
+            IF p_tag_mode = 'none' THEN
+                RETURN;
+            END IF;
+
+            IF p_owner_id IS NOT NULL THEN
+                -- Session-aware fetch with tag filtering
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %1$I.worker_queue q
+                LEFT JOIN %1$I.sessions s ON s.session_id = q.session_id AND s.locked_until > p_now_ms
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  -- Redundant bound so the cached generic plan can estimate
+                  -- selectivity and use idx_worker_visible (see migration header).
+                  AND q.visible_at <= statement_timestamp()
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND (
+                    q.session_id IS NULL
+                    OR s.worker_id = p_owner_id
+                    OR s.session_id IS NULL
+                  )
+                  AND (
+                    CASE p_tag_mode
+                        WHEN 'default_only' THEN q.tag IS NULL
+                        WHEN 'tags' THEN q.tag = ANY(p_tag_filter)
+                        WHEN 'default_and' THEN (q.tag IS NULL OR q.tag = ANY(p_tag_filter))
+                        WHEN 'any' THEN TRUE
+                        ELSE FALSE
+                    END
+                  )
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            ELSE
+                -- Non-session fetch with tag filtering
+                SELECT q.id, q.session_id INTO v_id, v_session_id
+                FROM %1$I.worker_queue q
+                WHERE q.visible_at <= TO_TIMESTAMP(p_now_ms / 1000.0)
+                  -- Redundant bound so the cached generic plan can estimate
+                  -- selectivity and use idx_worker_visible (see migration header).
+                  AND q.visible_at <= statement_timestamp()
+                  AND (q.lock_token IS NULL OR q.locked_until <= p_now_ms)
+                  AND q.session_id IS NULL
+                  AND (
+                    CASE p_tag_mode
+                        WHEN 'default_only' THEN q.tag IS NULL
+                        WHEN 'tags' THEN q.tag = ANY(p_tag_filter)
+                        WHEN 'default_and' THEN (q.tag IS NULL OR q.tag = ANY(p_tag_filter))
+                        WHEN 'any' THEN TRUE
+                        ELSE FALSE
+                    END
+                  )
+                ORDER BY q.id
+                LIMIT 1
+                FOR UPDATE OF q SKIP LOCKED;
+            END IF;
+
+            IF NOT FOUND THEN
+                RETURN;
+            END IF;
+
+            out_lock_token := 'lock_' || gen_random_uuid()::TEXT;
+
+            -- Increment attempt_count and lock the item
+            UPDATE %1$I.worker_queue
+            SET lock_token = out_lock_token,
+                locked_until = p_now_ms + p_lock_timeout_ms,
+                attempt_count = attempt_count + 1
+            WHERE id = v_id;
+
+            SELECT work_item, attempt_count
+            INTO out_work_item, out_attempt_count
+            FROM %1$I.worker_queue
+            WHERE id = v_id;
+
+            -- If session-bound, upsert the sessions row
+            IF v_session_id IS NOT NULL AND p_owner_id IS NOT NULL THEN
+                v_session_locked_until := p_now_ms + COALESCE(p_session_lock_timeout_ms, p_lock_timeout_ms);
+
+                INSERT INTO %1$I.sessions (session_id, worker_id, locked_until, last_activity_at)
+                VALUES (v_session_id, p_owner_id, v_session_locked_until, p_now_ms)
+                ON CONFLICT (session_id) DO UPDATE
+                SET worker_id = p_owner_id,
+                    locked_until = v_session_locked_until,
+                    last_activity_at = p_now_ms
+                WHERE %1$I.sessions.locked_until <= p_now_ms OR %1$I.sessions.worker_id = p_owner_id;
+
+                -- If upsert affected 0 rows, another worker owns this session.
+                -- Roll back: clear lock so item can be retried.
+                IF NOT FOUND THEN
+                    UPDATE %1$I.worker_queue
+                    SET lock_token = NULL,
+                        locked_until = NULL,
+                        attempt_count = attempt_count - 1
+                    WHERE id = v_id;
+                    RETURN;
+                END IF;
+            END IF;
+
+            RETURN NEXT;
+        END;
+        $fetch_worker$ LANGUAGE plpgsql;
+    $body$, v_schema_name);
+
+    RAISE NOTICE 'Migration 0022: fetch_work_item now bounds visible_at by statement_timestamp() so the cached plan uses idx_worker_visible';
+END $$;

--- a/scripts/bench-fetch-work-item.sh
+++ b/scripts/bench-fetch-work-item.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# fetch_work_item micro-benchmark: baseline vs. migration 0022 (generic-plan fix).
+#
+# Reproduces the defect fixed by migration 0022: inside the PL/pgSQL function the
+# dequeue SELECT is planned once and cached as a GENERIC plan, which cannot
+# estimate `visible_at <= $param` and therefore walks worker_queue_pkey in id
+# order, filtering every future-visible row by hand. Cost grows linearly with the
+# number of rows whose visible_at is still in the future.
+#
+# This builds two throwaway databases from this repo's own migration files -- one
+# at 0021 (baseline) and one at 0022 (adds the redundant statement_timestamp()
+# bound) -- loads FUTURE not-yet-visible rows plus one visible row into
+# worker_queue, then times N real fetch_work_item() calls against each.
+#
+# The calls run in a DO loop so the inner SELECT is executed many times in one
+# session: after ~5 executions PostgreSQL switches the function's cached plan to
+# the generic plan, which is the steady-state production behaviour. A warmup loop
+# forces that switch before timing. Each measured call re-frees the one visible
+# row it claims, so every iteration scans past the FUTURE rows to reach it.
+#
+# Requires: psql, and a PostgreSQL the current user can create databases on.
+# Connection is taken from the standard libpq environment variables
+# (PGHOST, PGPORT, PGUSER, PGPASSWORD, ...); override as needed.
+#
+# Usage:
+#   PGHOST=localhost PGPORT=5432 PGUSER=postgres scripts/bench-fetch-work-item.sh
+#
+# Tunables (env): FUTURE  not-yet-visible rows in the queue (default 100000)
+#                 NCALLS  fetch_work_item calls timed        (default 500)
+#                 MIGRATIONS_DIR (defaults to ../migrations relative to this file)
+#
+# Expected shape (hardware-dependent):
+#   BASELINE (0021): grows ~0.00044 ms per future-visible row (~44 ms at 100k)
+#   FIX (0022):      ~0.01-0.02 ms / call, flat regardless of FUTURE
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)/migrations}"
+FUTURE="${FUTURE:-100000}"
+NCALLS="${NCALLS:-500}"
+
+psql_c() { psql -X -q -v ON_ERROR_STOP=1 "$@"; }
+
+FIX_MIGRATION="0022_fix_fetch_work_item_generic_plan.sql"
+if [[ ! -f "$MIGRATIONS_DIR/$FIX_MIGRATION" ]]; then
+  echo "ERROR: $MIGRATIONS_DIR does not contain $FIX_MIGRATION" >&2
+  echo "       set MIGRATIONS_DIR to the duroxide-pg migrations/ directory." >&2
+  exit 1
+fi
+
+echo "Building throwaway databases from $MIGRATIONS_DIR ..."
+psql_c -d postgres -c "DROP DATABASE IF EXISTS dq_base;" -c "CREATE DATABASE dq_base;"
+psql_c -d postgres -c "DROP DATABASE IF EXISTS dq_fix;"  -c "CREATE DATABASE dq_fix;"
+
+# Baseline = every migration EXCEPT 0022; Fix = all migrations.
+for f in $(ls "$MIGRATIONS_DIR"/0*.sql | sort); do
+  base=$(basename "$f")
+  [[ "$base" == 0022_* ]] || psql_c -d dq_base -f "$f" >/dev/null
+  psql_c -d dq_fix -f "$f" >/dev/null
+done
+
+echo -n "  dq_base fetch_work_item bounds by statement_timestamp (expect f): "
+psql_c -d dq_base -tA -c "SELECT pg_get_functiondef('fetch_work_item(bigint,bigint,text,bigint,text[],text)'::regprocedure) LIKE '%statement_timestamp%';"
+echo -n "  dq_fix  fetch_work_item bounds by statement_timestamp (expect t): "
+psql_c -d dq_fix  -tA -c "SELECT pg_get_functiondef('fetch_work_item(bigint,bigint,text,bigint,text[],text)'::regprocedure) LIKE '%statement_timestamp%';"
+
+read -r -d '' AB_SQL <<'SQL' || true
+TRUNCATE worker_queue;
+-- :future rows whose visible_at is one hour in the future (never returnable) ...
+INSERT INTO worker_queue (work_item, visible_at, created_at)
+SELECT 'future', clock_timestamp() + interval '1 hour', clock_timestamp()
+FROM generate_series(1, :future) g;
+-- ... plus one row visible now, which every call will find and re-free.
+INSERT INTO worker_queue (work_item, visible_at, created_at)
+VALUES ('visible', clock_timestamp() - interval '1 second', clock_timestamp());
+ANALYZE worker_queue;
+
+-- Parameters are passed as a custom GUC because psql does not interpolate :vars
+-- inside a dollar-quoted DO block.
+SET my.ncalls = :ncalls;
+DO $$
+DECLARE
+    t0 timestamptz; t1 timestamptz; i int; got int := 0; r record;
+    v_ncalls int := current_setting('my.ncalls')::int;
+    v_now    bigint;
+BEGIN
+    -- Warmup: force the function's cached plan to switch to the generic plan
+    -- (PostgreSQL does this after ~5 executions). Not timed.
+    FOR i IN 1..10 LOOP
+        v_now := (extract(epoch FROM clock_timestamp()) * 1000)::bigint;
+        SELECT * INTO r FROM fetch_work_item(v_now, 30000);
+        UPDATE worker_queue SET lock_token = NULL, locked_until = NULL,
+               attempt_count = attempt_count - 1 WHERE lock_token = r.out_lock_token;
+    END LOOP;
+
+    t0 := clock_timestamp();
+    FOR i IN 1..v_ncalls LOOP
+        v_now := (extract(epoch FROM clock_timestamp()) * 1000)::bigint;
+        SELECT * INTO r FROM fetch_work_item(v_now, 30000);
+        IF r.out_work_item IS NOT NULL THEN got := got + 1; END IF;
+        -- Re-free the claimed row by exact (indexed) token match so the reset
+        -- cost does not dominate the measured fetch cost.
+        UPDATE worker_queue SET lock_token = NULL, locked_until = NULL,
+               attempt_count = attempt_count - 1 WHERE lock_token = r.out_lock_token;
+    END LOOP;
+    t1 := clock_timestamp();
+    RAISE NOTICE 'fetched=% of % calls  total=% ms  per_call=% ms',
+        got, v_ncalls,
+        round(extract(epoch FROM (t1-t0))*1000.0, 1),
+        round(extract(epoch FROM (t1-t0))*1000.0/v_ncalls, 4);
+END $$;
+SQL
+
+run_ab() {
+  psql_c -d "$1" -v future="$FUTURE" -v ncalls="$NCALLS" <<<"$AB_SQL"
+}
+
+echo
+echo "==== BASELINE (migrations 0001-0021) — $FUTURE future-visible rows, $NCALLS calls ===="
+run_ab dq_base
+echo
+echo "==== FIX (migrations 0001-0022) — same data ===="
+run_ab dq_fix
+echo
+echo "Done. (databases dq_base / dq_fix left in place; rerun drops+rebuilds them.)"


### PR DESCRIPTION
What
---
Migration 0022 fixes a latency defect in fetch_work_item: dequeue time grows linearly with the number of jobs scheduled for the future (timers/delays), even though those rows can never be returned.

Why
---
Inside the PL/pgSQL function the dequeue SELECT is cached as a generic plan. The generic planner cannot estimate the selectivity of visible_at <= $param, so with ORDER BY id LIMIT 1 it walks worker_queue_pkey in id order and filters every future-visible row by hand — O(future-visible rows) per dequeue.
- ~0.44 µs per future-visible row; ~44 ms at 100k rows; crosses 10 ms near 25k.
- The identical query with literal values runs in ~0.006 ms using the existing idx_worker_visible(visible_at, lock_token). The cost is the cached plan, not a missing index.
- Reproduces on main, independent of any index change.

Fix
---
Add a second, redundant upper bound to the same predicate:
AND q.visible_at <= statement_timestamp()
statement_timestamp() is a stable expression the generic plan can estimate, so it uses idx_worker_visible instead of the primary-key walk. Nothing else about eligibility changes — the authoritative visible_at <= TO_TIMESTAMP(p_now_ms/1000.0) bound is kept, so a row is returned only if it passes both bounds.
Measured: ~25 ms → ~0.15 ms per dequeue at 100k future-visible rows, flat as they pile up, with no dequeue-throughput regression (unlike force_custom_plan, which cost ~16–20%). Reproduce via scripts/bench-fetch-work-item.sh.

Correctness note (reviewers, please confirm)
---
The added bound gates visibility on the database clock, which is in tension with migration 0006 (which deliberately moved time logic onto the application-supplied p_now_ms). It can never return a not-yet-visible row, duplicate, or reorder. The only effect is a liveness one: if a worker's clock runs ahead of the database's, a due timer fires late by up to the clock skew — bounded, self-healing, never lost. Under normal NTP the window is negligible. If we'd rather keep the DB clock out of it entirely, the clock-agnostic alternative is force_custom_plan, at the ~16–20% dequeue-throughput cost noted above.

Scope
---
fetch_work_item only. fetch_orchestration_item was checked and is not affected: it orders by visible_at and already uses idx_orch_visible, staying flat (~0.13 ms) at 100k future-visible rows.
Supersedes
The earlier partial-index + two-phase approach in this PR. Measurements showed it helps only with a large backlog of claimed rows clustered at the queue head (not a realistic regime), regresses enqueue throughput (−5.3% / +12% WAL), and introduced a crash-recovery starvation case. Dropped in favour of this fix.

Verification
---
- Migrations apply via both psql and the crate migration runner.
- Passing suites: provider (incl. session, tag-filtering, lock-expiration, queue-semantics), basic, regression, session e2e, and stress.