### PR TITLE
perf(indexes): make mostly-NULL secondary indexes partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Make mostly-NULL secondary indexes partial (migration `0023`).** Three
+  secondary indexes cover columns that are NULL for the majority of rows, yet a
+  plain B-tree still stored an entry for every row: `worker_queue.session_id`
+  (NULL for non-session work items), `worker_queue.tag` (NULL for untagged items),
+  and `orchestrator_queue.lock_token` (NULL for unclaimed rows). Each is only ever
+  probed by a concrete non-NULL value, so they are now `... WHERE <col> IS NOT NULL`.
+  On a 500k-row load (~5% sessioned/tagged, ~10% claimed) this shrank the indexes
+  ~12x/~18x/~2x (session/tag/lock) and cut bulk-insert time ~16%, with value lookups
+  still index-served. This is a distribution-dependent write-path win: the savings
+  scale with how NULL-heavy the columns are (the figures use a ~95%-NULL,
+  i.e. non-session/untagged, population), so a session- or tag-heavy workload sees
+  little benefit — but no regression, as value lookups still use the indexes.
+  Reproduce via `scripts/bench-secondary-indexes.sh`.
+  (`0022` is reserved by the concurrent worker_queue dequeue change; this migration
+  is independent of it.)
+
 ### Security
 
 - **Pin `pg_temp` last in the migration `search_path`.** Each migration was applied

--- a/migrations/0023_partial_secondary_indexes.sql
+++ b/migrations/0023_partial_secondary_indexes.sql
@@ -1,0 +1,49 @@
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the MIT License.
+
+-- Migration 0023: make mostly-NULL secondary indexes partial
+--
+-- NOTE: 0022 is reserved by the concurrent worker_queue dequeue PR
+-- (perf/worker-queue-partial-index-dequeue). This migration is independent of it
+-- and applies cleanly whether or not 0022 is present; the runner applies pending
+-- migrations by version and tolerates the gap.
+--
+-- Three secondary indexes cover columns that are NULL for the majority of rows,
+-- yet a plain B-tree still stores an entry for every row (including the NULLs).
+-- Each is only ever probed by a concrete non-NULL value, so restricting the index
+-- to the non-NULL rows keeps it serving those lookups while shrinking it and
+-- removing index maintenance / autovacuum work for the common (NULL) insert path:
+--
+--   worker_queue.session_id      -- NULL for every non-session work item
+--   worker_queue.tag             -- NULL for every untagged (default) work item
+--   orchestrator_queue.lock_token -- NULL for every unclaimed row
+--
+-- Usage that keeps working (all match only non-NULL values):
+--   session routing/takeover:  WHERE session_id = <id>, JOIN ON s.session_id = q.session_id
+--   tag routing:               WHERE tag = ANY(<tags>)
+--   orchestrator ack:          DELETE ... WHERE lock_token = <token>
+
+DO $$
+DECLARE
+    v_schema_name TEXT := current_schema();
+BEGIN
+    EXECUTE format('DROP INDEX IF EXISTS %1$I.idx_worker_queue_session_id', v_schema_name);
+    EXECUTE format(
+        'CREATE INDEX idx_worker_queue_session_id ON %1$I.worker_queue (session_id) WHERE session_id IS NOT NULL',
+        v_schema_name
+    );
+
+    EXECUTE format('DROP INDEX IF EXISTS %1$I.idx_worker_queue_tag', v_schema_name);
+    EXECUTE format(
+        'CREATE INDEX idx_worker_queue_tag ON %1$I.worker_queue (tag) WHERE tag IS NOT NULL',
+        v_schema_name
+    );
+
+    EXECUTE format('DROP INDEX IF EXISTS %1$I.idx_orch_lock', v_schema_name);
+    EXECUTE format(
+        'CREATE INDEX idx_orch_lock ON %1$I.orchestrator_queue (lock_token) WHERE lock_token IS NOT NULL',
+        v_schema_name
+    );
+
+    RAISE NOTICE 'Migration 0023: session_id, tag, and orchestrator lock_token indexes are now partial (WHERE NOT NULL)';
+END $$;

--- a/scripts/bench-secondary-indexes.sh
+++ b/scripts/bench-secondary-indexes.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Secondary-index size/insert benchmark: baseline vs. migration 0023.
+#
+# Builds two throwaway databases from this repo's migration files -- one at 0021
+# (baseline, full B-tree secondary indexes) and one with 0023 (session_id / tag /
+# orchestrator lock_token indexes made partial WHERE NOT NULL) -- loads a realistic
+# population where most rows have NULL session_id/tag and most orchestrator rows are
+# unclaimed, then reports secondary-index sizes and bulk-insert time for each.
+#
+# Requires: psql, and a PostgreSQL the current user can create databases on.
+# Connection is taken from the standard libpq environment variables
+# (PGHOST, PGPORT, PGUSER, PGPASSWORD, ...); override as needed.
+#
+# Usage:
+#   PGHOST=localhost PGPORT=5432 PGUSER=postgres scripts/bench-secondary-indexes.sh
+#
+# Tunables (env): N  worker rows (default 500000, ~5% sessioned, ~5% tagged)
+#                 NO orchestrator rows (default 100000, ~10% claimed)
+#                 MIGRATIONS_DIR (defaults to ../migrations relative to this file)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)/migrations}"
+N="${N:-500000}"
+NO="${NO:-100000}"
+
+psql_c() { psql -X -q -v ON_ERROR_STOP=1 "$@"; }
+
+if [[ ! -f "$MIGRATIONS_DIR/0023_partial_secondary_indexes.sql" ]]; then
+  echo "ERROR: $MIGRATIONS_DIR does not contain 0023_partial_secondary_indexes.sql" >&2
+  exit 1
+fi
+
+echo "Building throwaway databases from $MIGRATIONS_DIR ..."
+psql_c -d postgres -c "DROP DATABASE IF EXISTS sec_base;" -c "CREATE DATABASE sec_base;"
+psql_c -d postgres -c "DROP DATABASE IF EXISTS sec_fix;"  -c "CREATE DATABASE sec_fix;"
+
+for f in $(ls "$MIGRATIONS_DIR"/0*.sql | sort); do
+  b=$(basename "$f")
+  [[ "$b" == 0023_* ]] || psql_c -d sec_base -f "$f" >/dev/null
+  psql_c -d sec_fix -f "$f" >/dev/null
+done
+
+read -r -d '' BODY <<'SQL' || true
+\set now 1900000000000
+TRUNCATE worker_queue;
+TRUNCATE orchestrator_queue;
+
+\echo '--- insert timing: :n worker rows (~5% sessioned, ~5% tagged) ---'
+\timing on
+INSERT INTO worker_queue (work_item, visible_at, created_at, session_id, tag)
+SELECT 'wi', to_timestamp((:now)/1000.0), now(),
+       CASE WHEN g % 20 = 0 THEN 'sess_'||(g%1000) ELSE NULL END,
+       CASE WHEN g % 20 = 1 THEN 'tag_'||(g%10)   ELSE NULL END
+FROM generate_series(1, :n) g;
+\timing off
+
+INSERT INTO orchestrator_queue (instance_id, work_item, visible_at, created_at, lock_token, locked_until)
+SELECT 'inst_'||g, 'wi', to_timestamp((:now)/1000.0), now(),
+       CASE WHEN g % 10 = 0 THEN 'lock_'||g ELSE NULL END,
+       CASE WHEN g % 10 = 0 THEN :now+300000 ELSE NULL END
+FROM generate_series(1, :no) g;
+
+ANALYZE worker_queue;
+ANALYZE orchestrator_queue;
+
+\echo '--- secondary index sizes ---'
+SELECT indexrelname,
+       pg_size_pretty(pg_relation_size(indexrelid)) AS size,
+       (SELECT reltuples::bigint FROM pg_class WHERE oid = indexrelid) AS est_entries
+FROM pg_stat_user_indexes
+WHERE indexrelname IN ('idx_worker_queue_session_id','idx_worker_queue_tag','idx_orch_lock')
+ORDER BY indexrelname;
+SQL
+
+run() { psql_c -d "$1" -v n="$N" -v no="$NO" <<<"$BODY"; }
+
+echo
+echo "==== BASELINE (migrations 0001-0021, full indexes) ===="
+run sec_base
+echo
+echo "==== FIX (with 0023, partial indexes) ===="
+run sec_fix
+echo
+echo "Done. (databases sec_base / sec_fix left in place; rerun drops+rebuilds them.)"


### PR DESCRIPTION
## Summary

Migration `0023` makes three mostly-NULL secondary indexes **partial** (`WHERE <col> IS NOT NULL`):

- `worker_queue.session_id` — NULL for every non-session work item
- `worker_queue.tag` — NULL for every untagged (default) work item
- `orchestrator_queue.lock_token` — NULL for every unclaimed row

## Why

Each of these columns is NULL for the majority of rows, yet a plain B-tree still stores an entry for **every** row (including the NULLs). Each index is only ever probed by a concrete non-NULL value — session routing/takeover, tag routing, and the orchestrator ack `DELETE … WHERE lock_token = <token>` — so the NULL entries are pure overhead: they bloat the index and add maintenance/autovacuum work that no query benefits from.

## Fix

Recreate the three indexes as partial `WHERE <col> IS NOT NULL`. Postgres skips a partial index entirely for rows that don't satisfy its predicate, so the ~95% of inserts with a NULL value now do **no work** on these indexes — no index tuple, no page split, no WAL, and nothing for autovacuum to reclaim later. That is the source of the speedup; it is a **write-path** win, not a lookup change. Reads by a concrete value still use the indexes.

## Measured

500k worker rows (~5% sessioned/tagged), 100k orchestrator rows (~10% claimed):

| Index | Before | After | Reduction |
|---|--:|--:|--:|
| `idx_worker_queue_session_id` | 3264 kB | 272 kB | ~12× |
| `idx_worker_queue_tag` | 3168 kB | 176 kB | ~18× |
| `idx_orch_lock` | 1120 kB | 536 kB | ~2× |
| bulk insert of 500k rows | 1576 ms | 1329 ms | ~16% faster |

Reproduce with `scripts/bench-secondary-indexes.sh`.

## Trade-off

This is a **distribution-dependent** write-path optimization. The savings scale with how NULL-heavy the columns are (the figures use a ~95%-NULL, i.e. non-session/untagged, population); a session- or tag-heavy workload sees little benefit — but **no regression**, as value lookups still use the indexes. The parameterized `tag = ANY($1)` was verified to still use the partial index even under a forced generic plan. The only path dropped is an `IS NULL` index scan, which the planner never chose anyway (NULL is the majority value → seq scan).

## Notes

- **Migration numbering:** `0022` is reserved by the concurrent `worker_queue` dequeue change; this migration is independent of it. The runner applies pending migrations by version and tolerates the gap, so `0023` applies cleanly with or without `0022` present.

## Testing

- `basic_tests`, `postgres_provider_test` (incl. session + tag-filtering), and `session_e2e_tests` all pass.
- Migration verified to apply via both `psql` and the crate's own migration runner (partial indexes present and value lookups still index-served in freshly created schemas).

Related: #18. That PR takes migration 0022; this one is 0023 and is independent of it.