### PR TITLE
docs: externalize crate publishing to Microsoft internal OSS infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Two test layers cover the Entra integration:
 - No API changes; no migrations required.
 - See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
+> **Releases are published by Microsoft's internal OSS infrastructure.** See [RELEASE_POLICY.md](RELEASE_POLICY.md) for details.
+
 ## Previous Release (0.1.32)
 
 - Bumped `duroxide` core dependency to `0.1.29`. The core 0.1.29 release replaces `futures::join_all`/`join`/`select_biased!` with replay-safe crate-local combinators that eliminate a latent large-fan-in (≥ 1024 children) replay hang. No provider-level code or schema changes required.

--- a/RELEASE_POLICY.md
+++ b/RELEASE_POLICY.md
@@ -1,0 +1,49 @@
+# Release Policy
+
+`duroxide-pg` is published to crates.io by Microsoft's internal open-source
+release infrastructure. The public repository contains the source, tests, and
+contributor release preparation; publishing credentials and release execution
+remain outside this repository.
+
+## For Open Source Contributors
+
+Contributors can propose version updates through pull requests. The normal
+workflow is:
+
+1. Update `Cargo.toml`, `CHANGELOG.md`, and the relevant documentation.
+2. Run the build, tests, and documentation checks.
+3. Open a pull request for review.
+
+After Microsoft maintainers merge a release change and create the corresponding
+version tag, the internal release process builds the tagged source and publishes
+the crate to crates.io.
+
+## What Contributors Should Not Do
+
+- Do not run `cargo publish` for the Microsoft release.
+- Do not create a manual crates.io release on behalf of the project.
+- Do not request or store Microsoft publishing credentials in this repository.
+
+## For Microsoft Maintainers
+
+After a release pull request is approved:
+
+1. Merge the pull request to `main`.
+2. Create and push the matching `vX.Y.Z` tag.
+3. Allow the internal OSS release pipeline to build and publish the crate.
+
+The internal pipeline validates the source, runs required compliance checks, and
+records release metadata and audit information. It publishes using the
+`microsoft-oss-releases` crates.io owner identity.
+
+## Crates.io Integrity
+
+crates.io does not provide cryptographic signing for published Rust crates.
+Integrity and authenticity rely on HTTPS transport, crates.io account security,
+and Cargo's package checksums recorded in `Cargo.lock`.
+
+## Support
+
+For questions about a release, open an issue in this repository or contact the
+duroxide maintainers. Do not add credentials or internal pipeline configuration
+to a public issue or pull request.

--- a/prompts/publish-crate.md
+++ b/prompts/publish-crate.md
@@ -85,20 +85,19 @@ git tag vX.Y.Z
 git push origin main --tags
 ```
 
-### 7. Publish to crates.io
+### 7. Tag for Release
 
-```bash
-cargo publish
-```
+Do not run `cargo publish`. Microsoft's internal OSS release pipeline detects the
+version tag and publishes `duroxide-pg` to crates.io.
 
-**Prerequisites:**
-- Must be logged in: `cargo login`
-- Must have publish permissions for the crate
+See [RELEASE_POLICY.md](../RELEASE_POLICY.md) for the public and internal
+responsibilities in the release workflow.
 
-### 8. Verify Publication
+### 8. Verify Release
 
-- Check https://crates.io/crates/duroxide-pg
-- Verify version appears and documentation is correct
+- Monitor the internal release pipeline for completion.
+- Verify the version appears at https://crates.io/crates/duroxide-pg after publication.
+- Contact the duroxide maintainers if the internal release does not complete.
 
 ## Example
 


### PR DESCRIPTION
This PR documents that duroxide-pg crate publishing is handled by Microsoft's internal OSS release infrastructure, moving publishing responsibility out of this public repository and its contributor-facing workflows.

## Changes

- Added `RELEASE_POLICY.md` describing the public contributor workflow and the internal release boundary.
- Updated `prompts/publish-crate.md` to remove manual `cargo publish` instructions and explain that the internal pipeline publishes after the version tag is created.
- Added a README notice linking to the release policy.

## Why This Change?

- Publishing credentials should not be distributed to public contributors.
- Releases should use the centrally managed, auditable Microsoft OSS release process.
- The public repository should clearly distinguish release preparation from publication.

## For Reviewers

- Documentation only; no Rust source changes.
- GitHub Actions build/test workflows remain unchanged.
- The existing version bump, PR review, merge, and tag workflow remains intact.
- The policy does not claim that crates.io provides cryptographic crate signing.
- Internal pipeline implementation details are intentionally not exposed.