### PR TITLE
chore: prepare release 0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-08-24
+
 ### Performance
 
 - **Make mostly-NULL secondary indexes partial (migration `0023`).** Three

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "pg-stress"]
 
 [package]
 name = "duroxide-pg"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 authors = ["Affan Dar <affandar@gmail.com>"]
 description = "A PostgreSQL-based provider implementation for Duroxide, a durable task orchestration framework"

--- a/README.md
+++ b/README.md
@@ -186,16 +186,16 @@ Two test layers cover the Entra integration:
 - Orchestration stats introspection via `Client::get_orchestration_stats()`
 - Microsoft Entra ID authentication for Azure Database for PostgreSQL (managed identity, Workload Identity, az CLI)
 
-## Latest Release (0.1.34)
+## Latest Release (0.1.35)
 
-- Adds `ProviderConfig`, `ConnectionConfig`, and `MigrationPolicy` so callers can select `ApplyAll` or `VerifyOnly` migration behavior at provider construction.
-- Breaking API cleanup: `PostgresProvider::new_with_config` now takes a single `ProviderConfig`; build URL configs with `ProviderConfig::url(...)` and Entra configs with `ProviderConfig::entra(...)`.
-- Hardens initialization by rejecting unsafe schema names and failing fast when the database has unknown migration versions.
+- Reduces write overhead and index size for mostly-NULL worker and orchestrator queue columns with migration `0023`.
+- Hardens future migrations against temporary-object shadowing by placing `pg_temp` last in the migration `search_path`.
+- Updates the provider and `pg-stress` companion crate to Duroxide 0.1.30.
 - See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
-## Previous Release (0.1.33)
+## Previous Release (0.1.34)
 
-- Fix: add `native-tls` feature to the `reqwest` dependency so HTTPS calls compiled into the crate (including AAD token acquisition for `connectWithEntra` / `connectWithSchemaAndEntra`) work end-to-end. Prior 0.1.32 binaries failed with `error sending request` / `invalid URL, scheme is not http` whenever Entra auth was used.
+- Adds `ProviderConfig`, `ConnectionConfig`, and `MigrationPolicy` for construction-time migration behavior, simplifies the configuration API, and hardens initialization against unsafe schema names and unknown migration versions.
 
 ## Support
 

--- a/migrations/0023_diff.md
+++ b/migrations/0023_diff.md
@@ -1,0 +1,38 @@
+# Diff for migration 0023
+
+**Migration file:** `0023_partial_secondary_indexes.sql`
+
+## Table Changes
+
+None.
+
+## New Indexes
+
+None. This migration replaces three existing indexes with partial indexes.
+
+## Index Changes
+
+### `idx_worker_queue_session_id` - predicate added (baseline: 0014)
+
+```diff
+-CREATE INDEX idx_worker_queue_session_id ON worker_queue(session_id);
++CREATE INDEX idx_worker_queue_session_id ON worker_queue(session_id) WHERE session_id IS NOT NULL;
+```
+
+### `idx_worker_queue_tag` - predicate added (baseline: 0016)
+
+```diff
+-CREATE INDEX idx_worker_queue_tag ON worker_queue(tag);
++CREATE INDEX idx_worker_queue_tag ON worker_queue(tag) WHERE tag IS NOT NULL;
+```
+
+### `idx_orch_lock` - predicate added (baseline: 0001)
+
+```diff
+-CREATE INDEX idx_orch_lock ON orchestrator_queue(lock_token);
++CREATE INDEX idx_orch_lock ON orchestrator_queue(lock_token) WHERE lock_token IS NOT NULL;
+```
+
+## Function Changes
+
+None.


### PR DESCRIPTION
## Summary

- bump `duroxide-pg` from 0.1.34 to 0.1.35
- publish the audited changelog entries for migration search-path hardening, Duroxide 0.1.30 compatibility, and partial queue indexes
- update the README latest/previous release summaries
- add the required `0023_diff.md` companion for migration `0023`

The release notes were checked against every commit and the complete diff since `v0.1.34`. Repository-only documentation, legal metadata, Entra test-infrastructure provisioning, and GitHub Actions maintenance are intentionally omitted from the user-facing release notes.

> [!IMPORTANT]
> This PR only prepares release metadata. The crate must be published by the approved internal Microsoft pipeline; do not run `cargo publish` manually.

## Validation

Run in clean Docker environments with Rust 1.97 and PostgreSQL 15 (`max_connections=500`):

- `cargo build`
- `cargo test`
- `cargo doc --no-deps`
- `cargo package -p duroxide-pg --allow-dirty` (56 files; package verification passed)
- `git diff --check`

## Post-Deploy Monitoring & Validation

- **Owner:** release operator / duroxide-pg maintainers
- **Validation window:** immediately after the internal pipeline completes, then observe representative workloads for 24 hours
- **Publication check:** confirm version `0.1.35` appears in the internal pipeline output and on the approved crate registry surface; verify generated documentation resolves for 0.1.35
- **Database check:** after a 0.1.35 provider initializes a test or canary schema, confirm `_duroxide_migrations` records migration `23`
- **Index check:** query `pg_indexes` for `idx_worker_queue_session_id`, `idx_worker_queue_tag`, and `idx_orch_lock`; each definition should contain the corresponding `WHERE ... IS NOT NULL` predicate
- **Logs/search terms:** watch for migration failures, `unknown migration`, `0023`, `search_path`, deadlock (`40P01`), and provider initialization errors
- **Metrics:** compare queue insert latency/throughput, database CPU, index size, and autovacuum activity with the pre-release baseline
- **Healthy signals:** initialization succeeds, queue lookups remain index-backed, no increase in provider retry/error rates, and NULL-heavy workloads show stable or improved write performance
- **Failure/mitigation trigger:** halt rollout if migration application fails, queue queries stop using the expected indexes, or provider/database error rates materially regress. Keep the prior application version available; migration `0023` changes only indexes and remains schema-compatible with 0.1.34, while index restoration can be handled by a reviewed follow-up migration if required.